### PR TITLE
Add CoffeeScript, Haskell, Ruby support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ A package for auto-titling your code. Supports indentation.
 ## Syntax supported
 
 - JavaScript
+- CoffeeScript
 - HTML
 - CSS
 - SASS/SCSS
 - Python
 - Shell/BASH
+- Haskell
+- Ruby
 
 All other syntaxes use the `//` inline comment syntax (that, of course, includes SASS/SCSS, C, etc);
 

--- a/lib/auto-sect.js
+++ b/lib/auto-sect.js
@@ -76,6 +76,21 @@ export default {
 			suffix: '',
 			titleChar: '-'
 		},
+		haskell: {
+			prefix: '{-',
+			suffix: '-}',
+			titleChar: '-'
+		},
+		ruby: {
+			prefix: '#',
+			suffix: '#',
+			titleChar: '-'
+		},
+		coffeescript: {
+			prefix: '#',
+			suffix: '',
+			titleChar: '-'
+		},
 		generic: {
 			prefix: '//',
 			suffix: '',

--- a/lib/util.js
+++ b/lib/util.js
@@ -23,6 +23,15 @@ const testKeys = [
 		regex: /bash|shell/
 	}, {
 		...python
+	}, {
+		syntax: 'haskell',
+		regex: /haskell/
+	}, {
+		syntax: 'ruby',
+		regex: /ruby/
+	}, {
+		syntax: 'coffeescript',
+		regex: /coffee/
 	}
 ];
 


### PR DESCRIPTION
Not a big deal, just added support for a few more languages that don't fit the `//` spec.
